### PR TITLE
Update ApplicationBuilder to work for julia v0.7!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ git:
 #    packages:
 #    - gfortran
 before_script: # homebrew for mac
-   - julia -e 'Pkg.add("Blink"); Pkg.build("Blink"); using Blink; Blink.AtomShell.install();'
+   - julia -e 'if (VERSION < v"0.7-") Pkg.add("Blink"); Pkg.build("Blink"); using Blink; Blink.AtomShell.install(); end'
 
 ## uncomment the following lines to override the default test script
 #script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,22 +4,16 @@ os:
   - osx
 julia:
   - 0.6
+  - 0.7
   - nightly
-matrix:
-  allow_failures:
-    - julia: nightly
+#matrix:
+#  allow_failures:
+#    - julia: nightly
 
 notifications:
   email: false
 git:
   depth: 99999999
-
-
-## uncomment the following lines to allow failures on nightly julia
-## (tests will run but not make your overall status red)
-#matrix:
-#  allow_failures:
-#  - julia: nightly
 
 ## uncomment and modify the following lines to manually install system packages
 #addons:

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.6
 PackageCompiler
 Glob
 ArgParse
+Compat

--- a/src/ApplicationBuilder.jl
+++ b/src/ApplicationBuilder.jl
@@ -23,7 +23,9 @@ by bundled applications before accessing any resources from the filesystem.
 """
 module App
 
-@static if is_apple()
+using Compat
+
+@static if Compat.Sys.isapple()
     if get(ENV, "COMPILING_APPLE_BUNDLE", "false") == "true"
         function change_dir_if_bundle()
             full_binary_name = PROGRAM_FILE  # PROGRAM_FILE is set manually in program.c

--- a/src/BuildApp.jl
+++ b/src/BuildApp.jl
@@ -132,7 +132,7 @@ function build_app_bundle(juliaprog_main;
         try
             #  an example output line from otool: "         path /Applications/Dev Apps/Julia-0.6.app/Contents/Resources/julia/lib (offset 12)"
             external_julia_deps = readlines(pipeline(`otool -l $binary_file`,
-                 `grep $(dirname(Base.JULIA_HOME))`,  # filter julia lib deps
+                 `grep $(dirname(Compat.Sys.BINDIR))`,  # filter julia lib deps
                  `sed 's/\s*path//'`, # remove leading "  path"
                  `sed 's/(.*)$//'`)) # remove trailing parens
             for line in external_julia_deps

--- a/src/BuildApp.jl
+++ b/src/BuildApp.jl
@@ -1,6 +1,7 @@
 module BuildApp
 
 using Glob, PackageCompiler
+using Compat  # For julia v0.6, v0.7, and v1.0
 
 export build_app_bundle
 
@@ -108,7 +109,7 @@ function build_app_bundle(juliaprog_main;
     # Compile the binary right into the app.
     println("~~~~~~ Compiling a binary from '$juliaprog_main'... ~~~~~~~")
 
-    custom_program_c = "$(Pkg.dir())/ApplicationBuilder/src/program.c"
+    custom_program_c = "$(@__DIR__)/program.c"
     # Provide an environment variable telling the code it's being compiled into a mac bundle.
     withenv("LD_LIBRARY_PATH"=>"$libsDir:$libsDir/julia",
             "COMPILING_APPLE_BUNDLE"=>"true") do
@@ -198,7 +199,7 @@ function build_app_bundle(juliaprog_main;
     write("$appDir/Info.plist", info_plist());
 
     # Copy Julia icons
-    julia_app_resources_dir() = joinpath(Base.JULIA_HOME, "..","..")
+    julia_app_resources_dir() = joinpath(Compat.Sys.BINDIR, "..","..")
     if (icns_file == nothing)
         icns_file = joinpath(julia_app_resources_dir(),"julia.icns")
         verbose && println("Attempting to copy default icons from Julia.app: $icns_file")

--- a/test/BuildApp.jl
+++ b/test/BuildApp.jl
@@ -1,6 +1,8 @@
 using Base.Test
 using ApplicationBuilder; using BuildApp;
 
+const julia_v07 = VERSION > v"0.7-"
+
 builddir = mktempdir()
 @assert isdir(builddir)
 
@@ -39,6 +41,7 @@ function testRunAndKillProgramSucceeds(cmd)
     return true
 end
 
+if !julia_v07  # Blink doesn't yet work on julia v0.7.
 @testset "HelloBlink.app" begin
 @test 0 == include("build_examples/blink.jl")
 
@@ -48,4 +51,5 @@ end
 @test isfile("$builddir/HelloBlink.app/Contents/Resources/main.js")
 # Test that it runs correctly
 @test testRunAndKillProgramSucceeds(`$builddir/HelloBlink.app/Contents/MacOS/blink`)
+end
 end


### PR DESCRIPTION
Most of the work to add 0.7 support was actually to add 0.7 support to
PackageCompiler, which was done here:
https://github.com/JuliaLang/PackageCompiler.jl/pull/88

This PR brings the code in ApplicationBuilder to julia v0.7 compatibility as
well.