### PR TITLE
Separate out the build files for each example.

### DIFF
--- a/test/build_examples/blink.jl
+++ b/test/build_examples/blink.jl
@@ -12,12 +12,16 @@ mbedTLSPkg = Pkg.dir("MbedTLS")
 
 @assert blinkPkg != nothing "Blink is not installed!"
 
+using Blink
+
 BuildApp.build_app_bundle(examples_blink;
     verbose = true,
     resources = [joinpath(blinkPkg, "deps","Julia.app"),
                  joinpath(blinkPkg, "src","AtomShell","main.js"),
                  joinpath(blinkPkg, "src","content","main.html"),
                  joinpath(blinkPkg, "res")],
-    libraries = [joinpath(httpParserPkg, "deps","usr","lib","libhttp_parser.dylib"),
-                 joinpath(mbedTLSPkg, "deps","usr","lib","libmbedcrypto.2.dylib")],
+    # Get the current library names directly from the packages that use them,
+    # which keeps this build script robust against lib version changes.
+    libraries = [HttpParser.lib,
+                 MbedTLS.libmbedcrypto],
     appname="HelloBlink", builddir=builddir)

--- a/test/build_examples/blink.jl
+++ b/test/build_examples/blink.jl
@@ -1,0 +1,23 @@
+using ApplicationBuilder; using BuildApp
+
+examples_blink = joinpath(@__DIR__, "..", "..", "examples", "blink.jl")
+
+# Allow this file to be called either as a standalone file to build the above
+# example, or from runtests.jl using a provided builddir.
+isdefined(:builddir) || (builddir=mktempdir())
+
+blinkPkg = Pkg.dir("Blink")
+httpParserPkg = Pkg.dir("HttpParser")
+mbedTLSPkg = Pkg.dir("MbedTLS")
+
+@assert blinkPkg != nothing "Blink is not installed!"
+
+BuildApp.build_app_bundle(examples_blink;
+    verbose = true,
+    resources = [joinpath(blinkPkg, "deps","Julia.app"),
+                 joinpath(blinkPkg, "src","AtomShell","main.js"),
+                 joinpath(blinkPkg, "src","content","main.html"),
+                 joinpath(blinkPkg, "res")],
+    libraries = [joinpath(httpParserPkg, "deps","usr","lib","libhttp_parser.dylib"),
+                 joinpath(mbedTLSPkg, "deps","usr","lib","libmbedcrypto.2.dylib")],
+    appname="HelloBlink", builddir=builddir)

--- a/test/build_examples/hello.jl
+++ b/test/build_examples/hello.jl
@@ -1,0 +1,10 @@
+using ApplicationBuilder; using BuildApp
+
+examples_hello = joinpath(@__DIR__, "..", "..", "examples", "hello.jl")
+
+# Allow this file to be called either as a standalone file to build the above
+# example, or from runtests.jl using a provided builddir.
+isdefined(:builddir) || (builddir=mktempdir())
+
+BuildApp.build_app_bundle(examples_hello;
+                          verbose=true, appname="HelloWorld", builddir=builddir)


### PR DESCRIPTION
Now, each file in test/build_examples/<f>.jl is a standalone example build
file for its corresponding examples/<f>.jl file. test/BuildApp.jl now
simply cycles through these example files.