### PR TITLE
Add `commandline_app` flag for Apps without a GUI.                                                                              On Mac, this will create an App bundle which simply opens a Terminal and runs your code.                                                                              I *believe* that on Windows, there's nothing special to be done; I think it will Just Work like this by default.

### DIFF
--- a/examples/commandline_hello.jl
+++ b/examples/commandline_hello.jl
@@ -2,7 +2,12 @@
 # Build this with the `commandline_app=true` flag in `BuildApp.build_app_bundle`.
 
 Base.@ccallable function julia_main(ARGS::Vector{String})::Cint
-    println("Oh hi, World!")
-    println("Current working directory: $(pwd())")
+    println("Hi what's your name?")
+    name = readline()
+    println("Oh hi, $name\! It's a pleasure to meet you.")
+    println("By the way, here's the current working directory:\n'$(pwd())'")
+
+    println("\nGoodbye! (Press enter to exit)")
+    readline()
     return 0
 end

--- a/examples/commandline_hello.jl
+++ b/examples/commandline_hello.jl
@@ -1,0 +1,8 @@
+# A super-simple command line program that just prints hello.
+# Build this with the `commandline_app=true` flag in `BuildApp.build_app_bundle`.
+
+Base.@ccallable function julia_main(ARGS::Vector{String})::Cint
+    println("Oh hi, World!")
+    println("Current working directory: $(pwd())")
+    return 0
+end

--- a/src/BuildApp.jl
+++ b/src/BuildApp.jl
@@ -7,12 +7,14 @@ export build_app_bundle
 @static if is_apple()
 
 include("sign_mac_app.jl")
+include("mac_commandline_app.jl")
 
 function build_app_bundle(juliaprog_main;
         appname=splitext(basename(juliaprog_main))[1], builddir = "builddir",
         resources = String[], libraries = String[], verbose = false,
         bundle_identifier = nothing, app_version = "0.1", icns_file = nothing,
         certificate = nothing, entitlements_file = nothing,
+        commandline_app = false,
     )
 
     builddir = abspath(builddir)
@@ -37,6 +39,11 @@ function build_app_bundle(juliaprog_main;
     launcherDir="$appDir/MacOS"
     resourcesDir="$appDir/Resources"
     libsDir="$appDir/Libraries"
+
+    if commandline_app
+        # Redefine launcherDir to put the binary where applet expects it.
+        launcherDir = build_commandline_app_bundle(builddir, binary_name, appname)
+    end
 
     mkpath(launcherDir)
 
@@ -157,7 +164,7 @@ function build_app_bundle(juliaprog_main;
         	<key>CFBundleDisplayName</key>
         	<string>$appname</string>
         	<key>CFBundleExecutable</key>
-        	<string>$binary_name</string>
+        	<string>$(commandline_app ? "applet" : binary_name)</string>
         	<key>CFBundleIconFile</key>
         	<string>$appname.icns</string>
         	<key>CFBundleIdentifier</key>

--- a/src/mac_commandline_app.jl
+++ b/src/mac_commandline_app.jl
@@ -1,0 +1,21 @@
+function get_commandline_applescript(exe_dir, executable_path)
+    """
+    set RootPath to POSIX path of (path to me)
+    tell application id "com.apple.terminal"
+      do script ("exec '" & RootPath & "$exe_dir/$executable_path'")
+      activate
+    end tell
+    """
+end
+
+function build_commandline_app_bundle(builddir, binary_name, appname)
+
+    applescript_file = "$builddir/build_$appname.applescript"
+    exe_dir = "Contents/app"
+    write(applescript_file, get_commandline_applescript(exe_dir, binary_name))
+
+    app_path = "$builddir/$appname.app"
+    run(`osacompile -o $app_path $applescript_file`)
+
+    return joinpath(app_path,exe_dir)
+end

--- a/test/BuildApp.jl
+++ b/test/BuildApp.jl
@@ -21,6 +21,11 @@ builddir = mktempdir()
 end
 end
 
+@testset "commandline_app" begin
+@test 0 == include("build_examples/commandline_hello.jl")
+@test success(`open $builddir/hello.app`)
+end
+
 
 function testRunAndKillProgramSucceeds(cmd)
     out, _, p = readandwrite(cmd) # Make sure it runs correctly

--- a/test/build_examples/commandline_hello.jl
+++ b/test/build_examples/commandline_hello.jl
@@ -1,0 +1,9 @@
+using ApplicationBuilder; using BuildApp
+
+# Allow this file to be called either as a standalone file to build the above
+# example, or from runtests.jl using a provided builddir.
+isdefined(:builddir) || (builddir=nothing)  # nothing == default builddir.
+
+build_app_bundle(joinpath(@__DIR__,"..","..","examples","commandline_hello.jl"),
+                 appname="hello",
+                 commandline_app=true, builddir=builddir)


### PR DESCRIPTION
This fixes Issue #16.

- [x] Verify this on windows before submitting.