### PR TITLE
Wrap all tests in `if isapple()` until linux/windows tests are added.

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,13 @@
 using Test
 
+# TODO: Make the tests work on Windows and Linux!!! :'(
+@static if Sys.isapple()
+
 @testset "Test ApplicationBuilder (by compiling examples/*.jl)" begin
     include("ApplicationBuilder.jl")
 end
 @testset "Command-line interface (compiling examples/*.jl)" begin
     include("build_app-cli.jl")
+end
+
 end


### PR DESCRIPTION
Opened an issue to remind us to add non-apple tests in the future:
https://github.com/NHDaly/ApplicationBuilder.jl/issues/39