### PR TITLE
Update linux/windows API to match macOS API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,11 @@ julia:
 #   allow_failures:
 #   - julia: nightly
 
+# Because we don't build all branches, manualy add a trigger to always build master.
+branches:
+  only:
+  - master
+
 notifications:
   email: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: julia
 
 os:
   - osx
-  #- linux  # TODO: Enable Linux
+  - linux
 
 julia:
   - 1.0

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ApplicationBuilder"
 uuid = "f9309374-59cc-5ff5-a120-e3e470a57b4a"
 authors = ["Nathan Daly <nhdaly@gmail.com>", "Ranjan Anantharaman <benditlikeranjan@gmail.com>"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"

--- a/src/ApplicationBuilder.jl
+++ b/src/ApplicationBuilder.jl
@@ -303,11 +303,7 @@ end
 end  # isapple
 
 @static if Sys.islinux() || Sys.iswindows()
-	include("bundle.jl")
-end
-
-@static if Sys.iswindows()
-    include("installer.jl")
+    include("bundle.jl")
 end
 
 end  # module

--- a/src/win-installer.jl
+++ b/src/win-installer.jl
@@ -1,4 +1,4 @@
-function installer(builddir; name = "nothing",
+function win_installer(builddir; name = "nothing",
 				license = "$JULIA_HOME/../License.md")
 
 	# check = success(`makensis`)

--- a/test/build_examples/commandline_hello.jl
+++ b/test/build_examples/commandline_hello.jl
@@ -5,5 +5,5 @@ using ApplicationBuilder
 @isdefined(builddir) || (builddir="builddir")
 
 build_app_bundle(joinpath(@__DIR__,"..","..","examples","commandline_hello.jl"),
-                 appname="hello",
+                 appname="hello", binary_name="hello",
                  commandline_app=true, builddir=builddir)

--- a/test/bundle.jl
+++ b/test/bundle.jl
@@ -1,0 +1,15 @@
+# Windows and Linux tests
+
+using Test
+using Pkg
+using ApplicationBuilder
+
+builddir = mktempdir()
+@assert isdir(builddir)
+
+@testset "HelloWorld.app" begin
+    @test 0 == include("build_examples/commandline_hello.jl")
+    @test isdir(joinpath(builddir, "hello"))
+    @test success(`$builddir/hello/bin/hello`)
+    #@test success(`open $builddir/hello.app`)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,15 +1,22 @@
 using Test
 
+@testset "ApplicationBuilder.jl" begin
+
 # TODO: Make the tests work on Windows and Linux!!! :'(
 @static if Sys.isapple()
 
-@testset "ApplicationBuilder.jl" begin
 @testset "Test ApplicationBuilder (by compiling examples/*.jl)" begin
     include("ApplicationBuilder.jl")
 end
 @testset "Command-line interface (compiling examples/*.jl)" begin
     include("build_app-cli.jl")
 end
+
+else  # Windows and Linux
+
+@testset "bundle.jl" begin
+    include("bundle.jl")
 end
 
+end
 end


### PR DESCRIPTION
Added features support:
  - binary_name
  - cpu_target
  - commandline_app
  - snoopfile
  - autosnoop

Part of fixing: https://github.com/NHDaly/ApplicationBuilder.jl/issues/26